### PR TITLE
add license to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,7 @@ To make sure your additions don't break `ui-components`, run `npm run test`, whi
 ## Deploying
 
 Visit the [Buildkite Master Branch](https://buildkite.com/sendgrid/ui-components/builds?branch=master) and select the SemVer appropriate to your deployment and you should be off and away. Make sure to post in FE Guild that a new version is going out.
+
+<a name="license"></a>
+# License
+[The MIT License (MIT)](LICENSE.txt)

--- a/README.md
+++ b/README.md
@@ -160,4 +160,4 @@ Visit the [Buildkite Master Branch](https://buildkite.com/sendgrid/ui-components
 
 <a name="license"></a>
 # License
-[The MIT License (MIT)](LICENSE.txt)
+[The MIT License (MIT)](LICENSE)


### PR DESCRIPTION
## Merge Checklist
<!-- Delete all that do not apply -->
- [ ] QA'd by Jason Walker (@two24studios)
- [ ] Code reviewed by a frontend lead (Steve Kinney, Alex Wicks, Chris Chalstrom, Alex Thomsen)
- [ ] If adding a new component, the component has been added to the exports in `src/index.ts`.
- [ ] Updated CHANGELOG.md
- [ ] Workflow: Title has [semver](http://semver.org/) bump level defined (#major, #minor, #patch, or #noversion)

There's nothing that mentions the license in README. I've added the license heading and that we follow MIT license in the readme with a link