### PR TITLE
update BannerMessage #patch

### DIFF
--- a/src/banner-message/BannerMessage.stories.tsx
+++ b/src/banner-message/BannerMessage.stories.tsx
@@ -15,5 +15,11 @@ stories.add('Banner Messages', () => (
     <BannerMessage type="beta">
       Beta banner with <strong>some jsx</strong>
     </BannerMessage>
+    <br />
+    <br />
+    <BannerMessage type="warning">
+      You are currently on a <strong>Deprecated Plan</strong> which we no longer
+      offer.
+    </BannerMessage>
   </Fragment>
 ));

--- a/src/banner-message/banner-message.module.scss
+++ b/src/banner-message/banner-message.module.scss
@@ -24,4 +24,10 @@
     background-color: rgba($sg-blue, 0.05);
     border-left: 2px solid $sg-blue;
   }
+
+  &-warning {
+    background-color: $alert-warning;
+    border-left: 2px solid $alert-warning-text;
+    color: $alert-warning-text;
+  }
 }

--- a/src/banner-message/index.tsx
+++ b/src/banner-message/index.tsx
@@ -4,10 +4,10 @@ import Styles from './banner-message.module.scss';
 
 export interface BannerMessageProps {
   className?: string;
-  type: 'beta' | 'info';
+  type: 'beta' | 'info' | 'warning';
 }
 
-const BannerMessage: React.SFC<BannerMessageProps> = ({
+export const BannerMessage: React.SFC<BannerMessageProps> = ({
   className,
   type,
   children,
@@ -23,4 +23,30 @@ const BannerMessage: React.SFC<BannerMessageProps> = ({
   </div>
 );
 
-export default BannerMessage;
+const DeprecatedBannerMessage: React.SFC<BannerMessageProps> = ({
+  className,
+  type,
+  children,
+}) => {
+  const deprecationMessage1 =
+    'WARNING: This export is being deprecated. Please update to use the following export:';
+  const deprecationMessage2 =
+    "import { BannerMessage } from '@sendgrid/ui-components';";
+  // tslint:disable-next-line: no-console
+  console.warn(deprecationMessage1);
+  // tslint:disable-next-line: no-console
+  console.warn(deprecationMessage2);
+  return (
+    <div
+      className={cn(
+        Styles['banner-message'],
+        className,
+        Styles[`banner-message-${type}`]
+      )}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default DeprecatedBannerMessage;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export {
 export { Action, Actions, ActionsCell } from './actions';
 export { Alert } from './alert';
 export { Badge } from './badge';
+export { BannerMessage } from './banner-message';
 export { Breadcrumb } from './breadcrumb';
 export { Button, Buttonized } from './button';
 export { ButtonList } from './button-list';


### PR DESCRIPTION
This PR makes a few updates to the BannerMessage component:
* Update BannerMessage export:
  * previously we were doing this: `import BannerMessage from '@sendgrid/ui-components/banner-message';`
  * and now we can do: `import BannerMessage from '@sendgrid/ui-components`
* Add a "warning" type
* Add a deprecation warning to the old export with a message on how to upgrade

## Merge Checklist
<!-- Delete all that do not apply -->
- [ ] Includes link to associated Github Issue or JIRA ticket
- [ ] Has descriptive PR title and body
- [ ] All changes are backwards compatible
- [ ] QA'd by the SendGrid Style Guide designer
- [ ] Code reviewed by a SendGrid frontend lead
- [ ] If adding a new component, the component has been added to the exports in `src/index.ts`.
